### PR TITLE
Make QDR functional on Windows

### DIFF
--- a/dell_runtime/dell_runtime_provider.py
+++ b/dell_runtime/dell_runtime_provider.py
@@ -25,7 +25,6 @@
 
 
 import logging
-
 logger = logging.getLogger(__name__)
 from .emulator_runtime_service import EmulatorRuntimeService
 from .remote_runtime_service import RemoteRuntimeService

--- a/dell_runtime/emulation_executor.py
+++ b/dell_runtime/emulation_executor.py
@@ -119,24 +119,27 @@ class EmulationExecutor():
         return self._temp_dir
 
     def _execute(self, statusvalue):
+        x_logger = logging.getLogger(__name__)
+
+
         statusvalue.value = STATUS_VALUES.index(RUNNING)
         try:
             executor_path = os.path.join(self._temp_dir, "executor.py")
             cmd = [sys.executable, executor_path]
-            logger.debug(f"starting {cmd}")
+            x_logger.debug(f"starting {cmd}")
             exec_result = subprocess.run(cmd, capture_output=True, text=True)
-            logger.debug(f"finished executing {cmd}")
-            logger.debug(f"stdout: {exec_result.stdout}")
-            logger.debug(f"stderr: {exec_result.stderr}")
+            x_logger.debug(f"finished executing {cmd}")
+            x_logger.debug(f"stdout: {exec_result.stdout}")
+            x_logger.debug(f"stderr: {exec_result.stderr}")
             exec_result.check_returncode()
             statusvalue.value = STATUS_VALUES.index(COMPLETED)
-            logger.debug(f"status: sent COMPLETED")
+            x_logger.debug(f"status: sent COMPLETED")
             self._post_run()
             sys.exit(0)
         except Exception as e:
             statusvalue.value = STATUS_VALUES.index(FAILED)
             self._post_run()
-            logger.debug(f"status: sent FAILED")
+            x_logger.debug(f"status: sent FAILED")
             sys.exit(1)
 
             
@@ -165,10 +168,13 @@ import sys
 import json
 import os
 from qiskit.providers.ibmq.runtime.utils import RuntimeDecoder
+import logging
+logger = logging.getLogger(__name__)
+
 
 if __name__ == "__main__":
     params = None
-    params_path = '{}'	
+    params_path = r'{}'	
     with open(params_path, 'r') as params_file:	
         params = params_file.read()
 
@@ -177,16 +183,16 @@ if __name__ == "__main__":
     provider = BackendProvider()
     if 'backend_name' in inputs:
         provider = BackendProvider()
-        print(inputs)
+        logger.debug(inputs)
         backend_name = inputs['backend_name']
-        print("using backend: " + backend_name)
+        logger.debug("using backend: " + backend_name)
         if 'backend_token' in inputs:
-            print('backend with token!')
+            logger.debug('backend with token!')
             backend = provider.get_backend(name = backend_name, backend_token=inputs["backend_token"])
         else:
             backend = provider.get_backend(name = backend_name)
     else:
-        print("using default backend: " + 'aer_simulator')
+        logger.debug("using default backend: " + 'aer_simulator')
         backend = provider.get_backend('aer_simulator')
 
     user_messenger = LocalUserMessengerClient({})
@@ -194,8 +200,8 @@ if __name__ == "__main__":
         main(backend, user_messenger=user_messenger, **inputs)
         
     except Exception as e:
-        print(e)
+        logger.debug(e)
         sys.exit(1)
-    print("exit")
+    logger.debug("exit")
   
 """

--- a/dell_runtime/emulator_runtime_job.py
+++ b/dell_runtime/emulator_runtime_job.py
@@ -110,7 +110,7 @@ class EmulatorRuntimeJob:
     def local_poll_for_results(self,callback):
         logger.debug(f"starting to listen to port {self.local_port}")
         self._sock.listen(1)
-        self._sock.settimeout(60)
+        self._sock.settimeout(120)
         try:
             conn, addr = self._sock.accept()
             logger.debug(f"accepted client connection from {addr}")

--- a/dell_runtime/emulator_runtime_job.py
+++ b/dell_runtime/emulator_runtime_job.py
@@ -108,12 +108,12 @@ class EmulatorRuntimeJob:
         return (self._status == "Failed" or self._status == "Completed" or self._status == "Canceled")
 
     def local_poll_for_results(self,callback):
-        logging.debug(f"starting to listen to port {self.local_port}")
+        logger.debug(f"starting to listen to port {self.local_port}")
         self._sock.listen(1)
-        self._sock.settimeout(3)
+        self._sock.settimeout(60)
         try:
             conn, addr = self._sock.accept()
-            logging.debug(f"accepted client connection from {addr}")
+            logger.debug(f"accepted client connection from {addr}")
             with conn:
                 while self._finalResults == None and not self._kill and not self.job_completed():
                     data = conn.recv(16384)

--- a/dell_runtime/local_user_messenger.py
+++ b/dell_runtime/local_user_messenger.py
@@ -33,10 +33,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class LocalUserMessengerClient(UserMessenger):
     def __init__(self, port):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        logger.debug(f"client connecting port {port}")
+        print(f"client connecting port {port}")
         self._sock.connect(('localhost', port))
 
     def publish(

--- a/examples/programs/qiskit_circuit_runner.py
+++ b/examples/programs/qiskit_circuit_runner.py
@@ -1,7 +1,8 @@
 from dell_runtime import DellRuntimeProvider
 from qiskit import QuantumCircuit
 import os
-
+import logging
+logging.basicConfig(level=logging.DEBUG)
 RUNTIME_PROGRAM = """
 # This code is part of qiskit-runtime.
 #
@@ -103,7 +104,7 @@ def main():
     
     job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
 
-    res = job.result(timeout=10)
+    res = job.result(timeout=120)
 
     print(f"res: {res}")
 

--- a/tests/test_emulator_runtime_job.py
+++ b/tests/test_emulator_runtime_job.py
@@ -139,7 +139,7 @@ class EmulatorRuntimeJobTest(unittest.TestCase):
         # runtime_program = provider.runtime.program(program_id)
         job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
         
-        result = job.result(timeout=15)
+        result = job.result(timeout=120)
         messages = job.get_unread_messages()
         logger.debug(f'unread messages {messages}')
             
@@ -167,7 +167,7 @@ class EmulatorRuntimeJobTest(unittest.TestCase):
         }
 
         job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
-        response = job.result(timeout=15)
+        response = job.result(timeout=120)
 
         results = response['results'][0]
 
@@ -203,7 +203,7 @@ class EmulatorRuntimeJobTest(unittest.TestCase):
         status = job.status()
         correct_status = status == "Creating" or status == "Running"
         self.assertTrue(correct_status)
-        job.result(timeout=15)
+        job.result(timeout=120)
         status = job.status()
 
         max_try = 50
@@ -232,7 +232,7 @@ class EmulatorRuntimeJobTest(unittest.TestCase):
         status = job.status()
         self.assertEqual(status, "Creating")
         
-        max_try = 50
+        max_try = 500
         attempt = 0
         while (status == "Creating" or status == "Running") and attempt < max_try:
             sleep(0.1)
@@ -286,7 +286,7 @@ class EmulatorRuntimeJobTest(unittest.TestCase):
         new_stdout = io.StringIO()
         sys.stdout = new_stdout
         job = provider.runtime.run(program_id, options=None, inputs=program_inputs,callback=print)
-        result =job.result(timeout=120)
+        result =job.result(timeout=600)
         output = new_stdout.getvalue()
         sys.stdout = old_stdout
         

--- a/tests/test_emulator_runtime_service.py
+++ b/tests/test_emulator_runtime_service.py
@@ -110,7 +110,7 @@ class EmulatorRuntimeServiceTest(unittest.TestCase):
         try:
             job = provider.runtime.run(program_id, options=None, inputs={"iterations": 2})
 
-            result = job.result(timeout=15)
+            result = job.result(timeout=120)
             self.assertIsNotNone(result)
         except Exception:
             self.fail("should pass")
@@ -216,7 +216,7 @@ class EmulatorRuntimeServiceTest(unittest.TestCase):
 
             job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
 
-            result = job.result(timeout=15)
+            result = job.result(timeout=120)
             self.assertIsNotNone(result)
         except Exception:
             self.fail("should pass")

--- a/tests/test_multi_local_backends.py
+++ b/tests/test_multi_local_backends.py
@@ -96,7 +96,7 @@ class MultiLocalBackendTest(unittest.TestCase):
         }
 
         job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
-        response = job.result(timeout=15)
+        response = job.result(timeout=120)
 
         results = response['results'][0]
 
@@ -126,7 +126,7 @@ class MultiLocalBackendTest(unittest.TestCase):
         }
 
         job = provider.runtime.run(program_id, options=None, inputs=program_inputs)
-        response = job.result(timeout=15)
+        response = job.result(timeout=120)
 
         results = response['results'][0]
 


### PR DESCRIPTION
Changed some timeouts that were too short for Windows operation, made one string in `emulation_executor.py` a literal string to deal with Windows file paths.